### PR TITLE
fmt and fix syntax errors

### DIFF
--- a/src/refcomponents/GoRef.jsx
+++ b/src/refcomponents/GoRef.jsx
@@ -6,34 +6,34 @@ export const GoRef = () => {
 
         <div className='code'>
             <pre>{`
-import (
- "some imports"
-)
+package chandy
+
+import "strings"
 
 type Cat struct {
-    Name, Color string
+	Name, Color string
 }
 
 func PublicCatFunc() Cat {
-    dagwood = Cat{"Dagwood", "Tabby I Guess"}
-    sully = Cat{Name: "Sully", Color:"Tabby I Guess"}
+	dagwood = Cat{"Dagwood", "Tabby I Guess"}
+	sully = Cat{Name: "Sully", Color: "Tabby I Guess"}
 }
 
 func privateArraysFunc() {
-    catNames := [2]string{
-    "Dagwood",
-    "Sully"
-    }
-    arr := make([]int, length, capacity)
-}
-func privateMapsFunc(s string) map[string]int{
-    m := make(map[string]int)
-    sArr := strings.Split(s, " ")
-    for index, elem := range sArr{
-        m[s] = m[s]+1
-    }
+	catNames := [2]string{
+		"Dagwood",
+		"Sully",
+	}
+	arr := make([]int, length, capacity)
 }
 
+func privateMapsFunc(s string) map[string]int {
+	m := make(map[string]int)
+	sArr := strings.Split(s, " ")
+	for index, elem := range sArr {
+		m[s] = m[s] + 1
+	}
+}
            `} </pre>
         </div>
     )


### PR DESCRIPTION
- add comma on line 24: the last element in newline separated array literals must be followed by a comma
- run `go fmt` command to format the code: it is frowned upon to not run the formatter when saving or committing code
- add `package chandy` package statement is required
- add `import "strings"` previous import was unused and the strings package was missing

I might do a review for idiomatic stuff later.